### PR TITLE
Faster create_pseudobulks function.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "pandas >= 1.3.3",
         "pyBigWig >= 0.3.17",
         "torch >= 1.9.0",
-        "tables >= 3.8.0"
+        "tables >= 3.8.0",
+        "numba >= 0.55"
     ],
 )


### PR DESCRIPTION
Faster create_pseudobulks function, by assuming that a lot of consecutive values will have the same value. Also streches of zeros are not stored at all.

Based on:
  https://github.com/aertslab/single_cell_toolkit/blob/c15038ddf1322fd4957396c16bb7782ad2e6629e/fragments_to_bw.py#L263C1-L372C82